### PR TITLE
Use raw messages when interaction messages are ephemeral

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -69,6 +69,7 @@ declare namespace Eris {
   type MessageContent = string | AdvancedMessageContent;
   type MFALevel = 0 | 1;
   type PossiblyUncachedMessage = Message | { channel: TextableChannel | { id: string; guild?: Uncached }; guildID?: string; id: string };
+  type PossiblyEphemeralMessage = Message | { id: string; flags: number };
 
   // Interaction
   type InteractionDataOptions = {
@@ -2373,7 +2374,7 @@ declare namespace Eris {
     };
     guildID?: string;
     member?: Member;
-    message: Message;
+    message: PossiblyEphemeralMessage;
     user?: User;
     acknowledge(): Promise<void>;
     createFollowup(content: string | InteractionWebhookContent): Promise<Message>;
@@ -2393,7 +2394,7 @@ declare namespace Eris {
     data?: unknown;
     guildID?: string;
     member?: Member;
-    message?: Message;
+    message?: PossiblyEphemeralMessage;
     type: number;
     user?: User;
     createFollowup(content: string | InteractionWebhookContent): Promise<Message>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -69,7 +69,7 @@ declare namespace Eris {
   type MessageContent = string | AdvancedMessageContent;
   type MFALevel = 0 | 1;
   type PossiblyUncachedMessage = Message | { channel: TextableChannel | { id: string; guild?: Uncached }; guildID?: string; id: string };
-  type PossiblyEphemeralMessage = Message | { id: string; flags: number };
+  type PossiblyEphemeralMessage = Message | { id: string; flags: 64 };
 
   // Interaction
   type InteractionDataOptions = {

--- a/lib/structures/ComponentInteraction.js
+++ b/lib/structures/ComponentInteraction.js
@@ -38,7 +38,7 @@ class ComponentInteraction extends Interaction {
         }
 
         if(data.message !== undefined) {
-            if(data.message.flags === InteractionFlags.EPHEMERAL) {
+            if(data.message.flags & InteractionFlags.EPHEMERAL) {
                 this.message = data.message;
             } else {
                 this.message = new Message(data.message, this._client);

--- a/lib/structures/ComponentInteraction.js
+++ b/lib/structures/ComponentInteraction.js
@@ -4,7 +4,7 @@ const Interaction = require("./Interaction");
 const Message = require("./Message");
 const Member = require("./Member");
 const User = require("./User");
-const {InteractionResponseTypes} = require("../Constants");
+const {InteractionResponseTypes, InteractionFlags} = require("../Constants");
 
 /**
 * Represents a message component interaction. See Interaction for more properties.
@@ -16,7 +16,7 @@ const {InteractionResponseTypes} = require("../Constants");
 * @prop {Array<String>?} data.values The value of the run selected options (Select Menus Only)
 * @prop {String?} guildID The ID of the guild in which the interaction was created
 * @prop {Member?} member The member who triggered the interaction (This is only sent when the interaction is invoked within a guild)
-* @prop {Message} message The message the interaction came from
+* @prop {Message?} message The message the interaction came from. If the message is ephemeral, this will be an object with `id` and `flags` keys.
 * @prop {User?} user The user who triggered the interaction (This is only sent when the interaction is invoked within a dm)
 */
 class ComponentInteraction extends Interaction {
@@ -38,7 +38,11 @@ class ComponentInteraction extends Interaction {
         }
 
         if(data.message !== undefined) {
-            this.message = new Message(data.message, this._client);
+            if(data.message.flags === InteractionFlags.EPHEMERAL) {
+                this.message = data.message;
+            } else {
+                this.message = new Message(data.message, this._client);
+            }
         }
 
         if(data.user !== undefined) {

--- a/lib/structures/UnknownInteraction.js
+++ b/lib/structures/UnknownInteraction.js
@@ -37,7 +37,7 @@ class UnknownInteraction extends Interaction {
         }
 
         if(data.message !== undefined) {
-            if(data.message.flags === InteractionFlags.EPHEMERAL) {
+            if(data.message.flags & InteractionFlags.EPHEMERAL) {
                 this.message = data.message;
             } else {
                 this.message = new Message(data.message, this._client);

--- a/lib/structures/UnknownInteraction.js
+++ b/lib/structures/UnknownInteraction.js
@@ -4,7 +4,7 @@ const Interaction = require("./Interaction");
 const Message = require("./Message");
 const Member = require("./Member");
 const User = require("./User");
-const {InteractionResponseTypes} = require("../Constants");
+const {InteractionResponseTypes, InteractionFlags} = require("../Constants");
 
 /**
 * Represents an unknown interaction. See Interaction for more properties.
@@ -13,7 +13,7 @@ const {InteractionResponseTypes} = require("../Constants");
 * @prop {Object?} data The data attached to the interaction
 * @prop {String?} guildID The ID of the guild in which the interaction was created
 * @prop {Member?} member The member who triggered the interaction (This is only sent when the interaction is invoked within a guild)
-* @prop {Message?} message The message the interaction came from (Message Component only)
+* @prop {Message?} message The message the interaction came from (Message Component only). If the message is ephemeral, this will be an object with `id` and `flags` keys.
 * @prop {User?} user The user who triggered the interaction (This is only sent when the interaction is invoked within a dm)
 */
 class UnknownInteraction extends Interaction {
@@ -37,7 +37,11 @@ class UnknownInteraction extends Interaction {
         }
 
         if(data.message !== undefined) {
-            this.message = new Message(data.message, this._client);
+            if(data.message.flags === InteractionFlags.EPHEMERAL) {
+                this.message = data.message;
+            } else {
+                this.message = new Message(data.message, this._client);
+            }
         }
 
         if(data.user !== undefined) {


### PR DESCRIPTION
This PR enables ephemeral messages to be passed through as they are from Discord's API (from what I happened to receive, an object with `id` and `flags` keys), resolving errors when using message components on ephemeral messages.