### PR TITLE
Fix error: Only iterables may be used in a SetType

### DIFF
--- a/lib/structures/ComponentInteraction.js
+++ b/lib/structures/ComponentInteraction.js
@@ -388,7 +388,7 @@ class ComponentInteraction extends Interaction {
                 embeds: content.embeds,
                 tts: content.tts,
                 flags: content.flags,
-                allowed_mentions: content.allowedMentions,
+                allowed_mentions: content.allowed_mentions,
                 components: content.components
             }
         }, content.file).then(() => this.update());


### PR DESCRIPTION
Hello, I encountered this issue: `data.allowed_mentions.users: Only iterables may be used in a SetType`
`content.allowedMentions` should be `content.allowed_mentions` in payload.