### PR TITLE
a few fixes/improvements

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2545,7 +2545,7 @@ declare namespace Eris {
 
   export class ComponentInteraction<T extends PossiblyUncachedTextable = TextableChannel> extends Interaction {
     channel: T;
-    data: ComponentInteractionButtonData | ComponentInteractionSelectMenuData | unknown;
+    data: ComponentInteractionButtonData | ComponentInteractionSelectMenuData;
     guildID?: string;
     member?: Member;
     message: Message;

--- a/index.d.ts
+++ b/index.d.ts
@@ -137,17 +137,34 @@ declare namespace Eris {
     required?: boolean;
   }
 
-  type ApplicationCommandOptionsString = Omit<ApplicationCommandOptionWithChoices<Constants["ApplicationCommandOptionTypes"]["STRING"]>, "choices" | "autocomplete">
-  & ({ choices: ApplicationCommandOptionChoice<Constants["ApplicationCommandOptionTypes"]["STRING"]>[]; autocomplete?: false } | { autocomplete: true });
-  type ApplicationCommandOptionsInteger = Omit<ApplicationCommandOptionWithChoices<Constants["ApplicationCommandOptionTypes"]["INTEGER"]>, "choices" | "autocomplete">
-  & ({ choices: ApplicationCommandOptionChoice<Constants["ApplicationCommandOptionTypes"]["INTEGER"]>[]; autocomplete?: false } | { autocomplete: true });
+  // String
+  type ApplicationCommandOptionsString = ApplicationCommandOptionsStringWithAutocomplete | ApplicationCommandOptionsStringWithoutAutocomplete;
+  type ApplicationCommandOptionsStringWithAutocomplete = Omit<ApplicationCommandOptionWithChoices<Constants["ApplicationCommandOptionTypes"]["STRING"]>, "choices">
+  & { autocomplete: true };
+  type ApplicationCommandOptionsStringWithoutAutocomplete = Omit<ApplicationCommandOptionWithChoices<Constants["ApplicationCommandOptionTypes"]["STRING"]>, "autocomplete">
+  & { autocomplete?: false };
+  // Integer
+  type ApplicationCommandOptionsInteger = ApplicationCommandOptionsIntegerWithAutocomplete | ApplicationCommandOptionsIntegerWithoutAutocomplete;
+  type ApplicationCommandOptionsIntegerWithAutocomplete = Omit<ApplicationCommandOptionWithChoices<Constants["ApplicationCommandOptionTypes"]["INTEGER"]>, "choices">
+  & { autocomplete: true };
+  type ApplicationCommandOptionsIntegerWithoutAutocomplete = Omit<ApplicationCommandOptionWithChoices<Constants["ApplicationCommandOptionTypes"]["INTEGER"]>, "autocomplete">
+  & {  autocomplete?: false };
+  // Boolean
   type ApplicationCommandOptionsBoolean = ApplicationCommandOption<Constants["ApplicationCommandOptionTypes"]["BOOLEAN"]>;
+  // User
   type ApplicationCommandOptionsUser = ApplicationCommandOption<Constants["ApplicationCommandOptionTypes"]["USER"]>;
+  // Channel
   type ApplicationCommandOptionsChannel = ApplicationCommandOption<Constants["ApplicationCommandOptionTypes"]["CHANNEL"]> & { channel_types?: ChannelTypes };
+  // Role
   type ApplicationCommandOptionsRole = ApplicationCommandOption<Constants["ApplicationCommandOptionTypes"]["ROLE"]>;
+  // Mentionable
   type ApplicationCommandOptionsMentionable = ApplicationCommandOption<Constants["ApplicationCommandOptionTypes"]["MENTIONABLE"]>;
-  type ApplicationCommandOptionsNumber = Omit<ApplicationCommandOptionWithChoices<Constants["ApplicationCommandOptionTypes"]["NUMBER"]>, "choices" | "autocomplete">
-  & ({ choices: ApplicationCommandOptionChoice<Constants["ApplicationCommandOptionTypes"]["NUMBER"]>[]; autocomplete?: false } | { autocomplete: true });
+  // Number
+  type ApplicationCommandOptionsNumber = ApplicationCommandOptionsNumberWithAutocomplete | ApplicationCommandOptionsNumberWithoutAutocomplete;
+  type ApplicationCommandOptionsNumberWithAutocomplete = Omit<ApplicationCommandOptionWithChoices<Constants["ApplicationCommandOptionTypes"]["NUMBER"]>, "choices">
+  & { autocomplete: true };
+  type ApplicationCommandOptionsNumberWithoutAutocomplete = Omit<ApplicationCommandOptionWithChoices<Constants["ApplicationCommandOptionTypes"]["NUMBER"]>, "autocomplete">
+  & { autocomplete?: false };
 
   interface ApplicationCommand<T extends (Constants["ApplicationCommandTypes"])[keyof Constants["ApplicationCommandTypes"]]
   = (Constants["ApplicationCommandTypes"])[keyof Constants["ApplicationCommandTypes"]]> {


### PR DESCRIPTION
The types are a bit wonky, I've added some things that fixed the issues I've seen

* I don't know why `unknown` was added to ComponentInteraction's `data` property, but it makes the property impossible to use without casting to a specific type (added in 0059f838fdbfbccbccfc3e0906f692d2dfab49c6, [error examples](https://butts-are.cool/Code_-_Insiders_09-26-2021_14-36-55.png))
* Converted the `ApplicationCommandOptions*` that have autocomplete into their own types, `ApplicationCommandOptions*WithAutocomplete` & `ApplicationCommandOptions*WithoutAutocomplete`, this makes the types look neater (in my opinion at least), and makes the error that is shown clearer